### PR TITLE
Replace dependancy on pyCrypto.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycrypto
+pycryptodome
 requests

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='googler',
-    version='1.0.1',
+    version='1.0.2',
     author='Christian Jurk',
     author_email='commx@commx.ws',
     description=('Google API Library for Python',),
@@ -27,7 +27,7 @@ setup(
     url='https://github.com/commx/googler',
     packages=find_packages(),
     install_requires=[
-        'pycrypto',
+        'pycryptodome',
         'requests'
     ],
     long_description='README.md',


### PR DESCRIPTION
pyCrypto is no longer maintained (https://github.com/dlitz/pycrypto/issues/238)

This switches googler to the pycryptodome fork, which is still actively maintained.